### PR TITLE
Disable PB_RespectIfNeeded on SuperGL

### DIFF
--- a/actors/Weapons/Slot5/SUPERGL.dec
+++ b/actors/Weapons/Slot5/SUPERGL.dec
@@ -94,7 +94,7 @@ ACTOR PB_SuperGL: PB_Weapon 13206
 	Inventory.PickupMessage "You got the UAC-MGL automatic grenade launcher! (Slot 6)"
 	Tag "Super Grenade Launcher"
 	Inventory.AltHUDIcon "SGL0Z0"
-	PB_WeaponBase.respectItem "RespectSGL"
+//	PB_WeaponBase.respectItem "RespectSGL"
 	States
 	{
 		Steady:
@@ -110,7 +110,7 @@ ACTOR PB_SuperGL: PB_Weapon 13206
 			SL42 ABCDEFGHI 0
 			S001 ABCDEFGHI 0
 			TNT1 A 0 A_GiveInventory("HasExplosiveWeapon", 1)
-			TNT1 A 0 PB_RespectIfNeeded
+			TNT1 A 0 A_JumpIfInventory("RespectSGL",1,"SelectAnimation") //PB_RespectIfNeeded
 		WeaponRespect:
 			TNT1 A 0 {
 				A_GiveInventory("RespectSGL");


### PR DESCRIPTION
Removed PB_RespectIfNeeded function due to a serious bug that the weapon disappears after firing unless you press weaponspecial.